### PR TITLE
[FRON-936] Translatable Elements in Datepicker/Timepicker

### DIFF
--- a/datepicker/src/lib/datepicker-module.ts
+++ b/datepicker/src/lib/datepicker-module.ts
@@ -16,27 +16,15 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatCalendar } from './calendar';
 import { MatCalendarBody } from './calendar-body';
 import { MatClockView } from './clock-view';
-import {
-  MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY_PROVIDER,
-  MatDatepicker,
-  MatDatepickerContent
-} from './datepicker';
+import { MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY_PROVIDER, MatDatepicker, MatDatepickerContent } from './datepicker';
 import { MatDatepickerInput } from './datepicker-input';
-import { MatDatepickerIntl } from './datepicker-intl';
 import { MatDatepickerToggle, MatDatepickerToggleIcon } from './datepicker-toggle';
 import { MatMonthView } from './month-view';
 import { MatYearView } from './year-view';
 import { MatYearsView } from './years-view';
 
 @NgModule({
-  imports: [
-    CommonModule,
-    MatButtonModule,
-    MatDialogModule,
-    MatIconModule,
-    OverlayModule,
-    A11yModule
-  ],
+  imports: [CommonModule, MatButtonModule, MatDialogModule, MatIconModule, OverlayModule, A11yModule],
   exports: [
     MatCalendar,
     MatCalendarBody,
@@ -63,7 +51,7 @@ import { MatYearsView } from './years-view';
     MatYearView,
     MatYearsView
   ],
-  providers: [MatDatepickerIntl, MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY_PROVIDER],
+  providers: [MAT_DATEPICKER_SCROLL_STRATEGY_FACTORY_PROVIDER],
   entryComponents: [MatDatepickerContent]
 })
 export class MatDatepickerModule {}

--- a/datepicker/src/lib/datepicker.ts
+++ b/datepicker/src/lib/datepicker.ts
@@ -151,6 +151,9 @@ export class MatDatepicker<D> implements OnInit, OnDestroy {
   @Input()
   twelveHour = true;
 
+  @Input()
+  color?: string;
+
   /**
    * Whether the calendar UI is in touch mode. In touch mode the calendar opens in a dialog rather
    * than a popup and elements have more padding to allow for bigger touch targets.


### PR DESCRIPTION
**Changes**
- Removed a provider that caused two instances of the class to exist, making impossible to pass translations into the component.

**Related tickets**
- https://selvera.atlassian.net/browse/FRON-936