### PR TITLE
Fix datepicker input always being disabled

### DIFF
--- a/datepicker/src/lib/datepicker-input.ts
+++ b/datepicker/src/lib/datepicker-input.ts
@@ -82,7 +82,7 @@ export class MatDatepickerInputEvent<D> {
     '[attr.aria-owns]': '(_datepicker?.opened && _datepicker.id) || null',
     '[attr.min]': 'min ? _dateAdapter.toIso8601(min) : null',
     '[attr.max]': 'max ? _dateAdapter.toIso8601(max) : null',
-    '[attr.disabled]': 'disabled',
+    '[attr.disabled]': 'disabled ? "disabled" : null',
     '(input)': '_onInput($event.target.value)',
     '(change)': '_onChange()',
     '(blur)': '_onBlur()',


### PR DESCRIPTION
This PR fixes the datepicker input element always being disabled regardless of the `disabled` input attribute. This is caused by passing a boolean for the disabled attribute to the host input element, which will be implicitly converted to the strings `"true"` or `"false"`, dependently on the boolean value, however, [according to the HTML5 standard](https://www.w3.org/TR/html51/infrastructure.html#sec-boolean-attributes), boolean attributes with false values must be left out completely (and true values can be either an empty string or the attribute name itself).